### PR TITLE
Allow mime < v0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ license = "Apache-2.0"
 
 [dependencies]
 url = "^1.2"
-mime = "^0.2"
+mime = ">=0.2, <0.4"


### PR DESCRIPTION
v0.3 of the `mime` dependency wasn't a breaking change, allow it to be used so
that consumers of this crate can more easily interoperate with other modern
packages (eg `reqwest`).